### PR TITLE
Add evaluateValue method to sanitze or evaluate input value if needed.

### DIFF
--- a/lib/tokenfield.js
+++ b/lib/tokenfield.js
@@ -497,7 +497,7 @@ class Tokenfield extends EventEmitter {
     let o = this._options;
     let html = this._html;
     let keyName = v.keys[e.keyCode];
-    let val = html.input.value.trim();
+    let val = this.evaluateValue(html.input.value).trim();
 
     let selected = this._getSelectedItems();
     if (selected.length) {

--- a/lib/tokenfield.js
+++ b/lib/tokenfield.js
@@ -851,15 +851,19 @@ class Tokenfield extends EventEmitter {
     });
     return this;
   }
+  
+  evaluateValue(value) {
+  	return value;
+  }
 
   _newItem(value) {
     let o = this._options;
-    let item = this._getItem(value, o.itemData);
+    let item = this._getItem(this.evaluateValue(value), o.itemData);
     if (! item && o.newItems) {
       item = {
         isNew: true,
         [this.key]: guid(),
-        [o.itemData]: value.trim()
+        [o.itemData]: this.evaluateValue(value).trim()
       };
       this.emit('newToken', this, item);
     }


### PR DESCRIPTION
I just added helper method "evaluateValue". 
It is for users to evaluate input value before adding token. 
It is mostly same as "renderSetItemLabel" method but for input value. 

For example, 
```
myTokenfield.evaluateValue = function(value) {
  return value.replace(/[^a-z0-9]/gi, '');
}
``` 