### PR TITLE
Fix: Cannot read property 'classList' of undefined

### DIFF
--- a/lib/tokenfield.js
+++ b/lib/tokenfield.js
@@ -774,7 +774,7 @@ class Tokenfield extends EventEmitter {
     this._vars.suggestedItems.forEach(v => {
       if (v.selected && v.el) {
         v.el.classList.add('selected');
-      } else {
+      } else if (v.el) {
         v.el.classList.remove('selected');
       }
     });


### PR DESCRIPTION
Using ReactJS (15.1.0)
Error was tokenfield.js:879 Uncaught TypeError: Cannot read property 'classList' of undefined 
And it happend when there was mouseOver event