### PR TITLE
Fix typo breaking new item values

### DIFF
--- a/lib/tokenfield.js
+++ b/lib/tokenfield.js
@@ -949,7 +949,7 @@ class Tokenfield extends EventEmitter {
     remove.key = item[this.key];
     input.setAttribute('name', (item.isNew ? o.newItemName : o.itemName) + '[]');
 
-    input.value = item[(item.isNew ? o.newitemValue : o.itemValue)] || null;
+    input.value = item[(item.isNew ? o.newItemValue : o.itemValue)] || null;
     label.textContent = this.renderSetItemLabel(item);
     if (item.focused) {
       itemHtml.classList.add('focused');


### PR DESCRIPTION
This was causing all new items to have a value of `null`, instead of using the `name` attribute of the new item.