### PR TITLE
bundling issue for browsers using es5

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "type": "git",
     "url": "https://github.com/KaneCohen/tokenfield.git"
   },
-  "module": "lib/tokenfield.js",
   "main": "dist/tokenfield.js",
   "license": "BSD-3-Clause",
   "devDependencies": {


### PR DESCRIPTION
fixed es5 bundling issue, where package bundlers uses the es6 version of the file instead of the es5 friendly